### PR TITLE
docs(growth): add communication pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Retired presentation and legacy URLs remain compatible without creating competin
 The product is ready for a controlled public launch around one clear idea: **a market result is more useful when its assumptions and failure conditions remain visible.**
 
 - [Public launch kit](docs/PUBLIC_LAUNCH_KIT.md) — approved positioning, channel sequence, and ready-to-adapt copy
+- [Communication pack](docs/COMMUNICATION_PACK.md) — bilingual launch copy aligned with the product truth and builder narrative
 - [GitHub social preview (1280 × 640)](website/public/social/epsilon-social-preview-v1.jpg)
 - [EPSILON v2.0 release](https://github.com/DresdenGman/EPSILON-trading-simulator/releases/tag/v2.0.0) — release notes, product film, and downloadable media assets
 

--- a/docs/COMMUNICATION_PACK.md
+++ b/docs/COMMUNICATION_PACK.md
@@ -1,0 +1,345 @@
+# EPSILON Communication Pack
+
+Status: `Working source copy · adapt the bracketed fields before posting`
+
+This pack keeps every public description of EPSILON aligned with one product truth and one personal narrative. It is not a collection of unrelated advertisements.
+
+## 1. The narrative spine
+
+### Personal thesis
+
+> **I do not build systems to make answers look more certain. I build systems that make conclusions easier to challenge.**
+
+Chinese:
+
+> **我不是在制造更肯定的答案，而是在设计一种让结论经得起质疑的系统。**
+
+### The recurring way of working
+
+```text
+Notice ambiguity
+      ↓
+Turn intuition into an explicit question
+      ↓
+Define what would prove the idea wrong
+      ↓
+Build a system that preserves evidence and limits
+      ↓
+Challenge the result
+      ↓
+Revise the question and retest
+```
+
+### What EPSILON proves about its builder
+
+EPSILON should be used as evidence of four qualities—not as a claim that its builder has solved financial markets:
+
+1. **Intellectual honesty:** unknown data stays unknown; negative results remain evidence.
+2. **Systems thinking:** the question, configuration, provenance, output, and critique are treated as one research object.
+3. **Independent execution:** an abstract research principle was turned into a working, open-source product.
+4. **Revision over attachment:** changing the question makes earlier evidence stale instead of silently rewriting it.
+
+### The memorable question
+
+> When a result looks convincing, what would have to be true for it to deserve our trust?
+
+Chinese:
+
+> 当一个结果看起来很有说服力时，究竟还需要满足什么条件，它才值得被相信？
+
+## 2. Canonical positioning
+
+### One sentence
+
+**EPSILON is an open-source quantitative decision lab that turns a market idea into a falsifiable research loop: observe, define, test, challenge, and retest.**
+
+Chinese:
+
+**EPSILON 是一个开源量化决策实验室，把市场直觉转化为可证伪的研究循环：观察、定义、测试、质疑与重新测试。**
+
+### Twenty-five words
+
+EPSILON keeps a market question, test configuration, result, provenance boundary, and failure condition together—so a backtest output cannot quietly become an overconfident conclusion.
+
+### What makes it different
+
+Most backtesting interfaces optimize for producing a performance number. EPSILON is designed around the lifecycle of a claim. If the question changes, earlier evidence becomes stale. If a retest fails operationally, it does not erase the last valid artifact. Missing provenance remains visible rather than being replaced with a plausible story.
+
+### Product category
+
+Use:
+
+- quantitative decision lab;
+- falsifiable market research environment;
+- open-source research workflow;
+- evidence-centered backtesting interface.
+
+Avoid:
+
+- AI trading platform;
+- stock predictor;
+- alpha generator;
+- institutional-grade market terminal;
+- profitable strategy engine.
+
+## 3. Verified proof points
+
+Public copy may state that EPSILON:
+
+- has one web workflow: **Market → Strategy Lab → Interrogate**;
+- allows a hypothesis and rejection condition to be recorded before testing;
+- keeps submitted inputs, metrics, trade evidence, and known/unknown provenance boundaries together;
+- marks evidence stale when the subject, hypothesis, or rejection condition changes;
+- preserves the last successful artifact when a later run fails;
+- provides a guest path without requiring an account;
+- labels guest-mode evidence as controlled synthetic simulation;
+- is open source and preserves its original desktop history in the same repository.
+
+Every public claim should be demonstrable through one of these links:
+
+- Product: https://epsilon-livid.vercel.app/landing
+- Workspace: https://epsilon-livid.vercel.app/dashboard
+- Strategy Lab: https://epsilon-livid.vercel.app/dashboard/backtest
+- Interrogate: https://epsilon-livid.vercel.app/dashboard/ai
+- Source: https://github.com/DresdenGman/EPSILON-trading-simulator
+- v2.0 release: https://github.com/DresdenGman/EPSILON-trading-simulator/releases/tag/v2.0.0
+- Product film: https://github.com/DresdenGman/EPSILON-trading-simulator/releases/download/v2.0.0/epsilon-decision-lab-30s.mp4
+
+## 4. Core public copy
+
+### Short English post
+
+> I built EPSILON around a question that bothered me: when a backtest looks convincing, what would have to be true for it to deserve our trust?
+>
+> EPSILON turns a market idea into a falsifiable loop—observe, define, test, challenge, and retest. The question, configuration, evidence boundaries, and failure condition stay attached to the result.
+>
+> It is open source, and the guest workspace is available without an account. I would value criticism of the research workflow—especially the assumption you would challenge first.
+>
+> Product: https://epsilon-livid.vercel.app/landing
+> Source: https://github.com/DresdenGman/EPSILON-trading-simulator
+
+### Short Chinese post
+
+> 我做 EPSILON，源于一个一直困扰我的问题：当一个回测结果看起来很有说服力时，究竟还需要满足什么条件，它才值得被相信？
+>
+> EPSILON 把市场直觉转化为一个可证伪的循环：观察、定义、测试、质疑、重新测试。问题、配置、证据边界和失败条件始终与结果绑定，而不是让一个漂亮数字脱离假设单独存在。
+>
+> 项目已经开源，访客无需注册即可体验。我最希望得到的不是一句“做得不错”，而是：**你会首先质疑这个研究流程中的哪一个假设？**
+>
+> 产品：https://epsilon-livid.vercel.app/landing
+> 源码：https://github.com/DresdenGman/EPSILON-trading-simulator
+
+## 5. Technical community version
+
+### Show HN
+
+**Title:** `Show HN: EPSILON – an open-source decision lab for falsifiable market research`
+
+> Hi HN — I originally built EPSILON as a desktop trading simulator. While working on it, I became less interested in producing another performance number and more interested in a harder problem: how quickly a clean result can become detached from the assumptions that produced it.
+>
+> I rebuilt the web product around the lifecycle of a claim. A user selects a market subject, writes a hypothesis and rejection condition, runs a controlled test, and inspects the submitted configuration, result, trade evidence, and known/unknown provenance together. If the question changes, the previous artifact becomes stale rather than being silently reused. A failed run cannot erase the last successful artifact.
+>
+> The public guest path uses clearly labeled browser-local synthetic evidence. It does not claim live data, historical validation, profitability, or investment advice.
+>
+> I would especially value methodological criticism: where does this workflow still make it too easy to over-interpret a result?
+>
+> Live product: https://epsilon-livid.vercel.app/landing
+> Source: https://github.com/DresdenGman/EPSILON-trading-simulator
+
+### Five-post technical thread
+
+**1/5**
+A backtest can produce a precise number while hiding an imprecise question. I built EPSILON to keep the claim, test configuration, evidence boundary, and failure condition in the same research loop.
+
+**2/5**
+The workflow is simple: Observe → Define → Test → Challenge → Retest. The important part is state: changing the question makes prior evidence stale instead of quietly reusing it.
+
+**3/5**
+Missing provenance is not filled with a plausible story. If the provider, sampling, fees, slippage, fill model, or benchmark is unknown, the interface keeps it unknown.
+
+**4/5**
+Guest mode uses controlled browser-local simulation. That demonstrates the workflow; it does not establish historical validity, robustness, profitability, or investment advice.
+
+**5/5**
+EPSILON v2.0 is open source. I am looking for methodological objections, not applause: what assumption would you challenge first?
+https://epsilon-livid.vercel.app/landing
+https://github.com/DresdenGman/EPSILON-trading-simulator
+
+## 6. Founder and investor version
+
+### Thirty-second introduction
+
+> EPSILON began as a trading simulator, but I realized the more interesting problem was not how to produce another result—it was how to stop a result from becoming detached from the assumptions behind it. I rebuilt it as a quantitative decision lab. A user defines a claim and failure condition, tests it, sees the evidence boundaries, challenges the interpretation, and retests without erasing history. The product reflects how I like to build: turn ambiguity into an explicit system, then design that system to question itself.
+
+### Chinese introduction
+
+> EPSILON 最初是一个交易模拟器，但我后来发现，更值得解决的问题不是怎样再生成一个结果，而是怎样防止结果脱离它背后的假设。我把它重构成了一个量化决策实验室：用户先定义命题和失败条件，再测试、查看证据边界、质疑解释，并在不抹去历史的情况下重新测试。这个产品也代表了我的做事方式：把模糊问题变成明确系统，再让这个系统具备质疑自身结论的能力。
+
+### Investor follow-up answers
+
+**Why does this need to exist?**
+Because a numerical output often receives more trust than its evidence warrants. EPSILON makes the conditions and limits of that output harder to lose.
+
+**Who is it for today?**
+Research-minded students, technical users, and quantitative builders who want an explicit workflow for testing and challenging market ideas.
+
+**What is the wedge?**
+Not broader market coverage. The wedge is evidence discipline: the research question, configuration, provenance, output, and challenge history remain connected.
+
+**What is not yet proven?**
+Market demand, retention, real historical validation, and any performance benefit. Early distribution should test whether users value the workflow—not imply those outcomes already exist.
+
+## 7. Builder narrative
+
+### Project description
+
+> I first approached EPSILON as a software problem: build a realistic trading simulator. But the project changed when I noticed that a precise backtest could still rest on an imprecise question. I began treating uncertainty not as something to hide, but as something the interface should preserve.
+>
+> I rebuilt EPSILON around falsifiability. Before a test, the user states a hypothesis and what would invalidate it. Afterward, the system keeps the configuration, result, missing evidence, and critique together. Changing the question marks the earlier result stale; a failed retest cannot rewrite history.
+>
+> EPSILON became more than a finance project for me. It taught me that building a system also means deciding how that system admits uncertainty, remembers failure, and corrects itself.
+
+### The role it plays in the larger body of work
+
+EPSILON should support—not replace—the broader builder narrative:
+
+> I am drawn to systems where a confident output can conceal an uncertain foundation. My response is to make the hidden assumptions explicit, build a structure that can be tested, and preserve the evidence needed to revise it.
+
+This framing makes EPSILON one piece of a repeatable intellectual pattern across projects. Do not present it as an isolated “finance app” or use unsupported claims about financial skill.
+
+### Three reusable insights
+
+1. **A change in question is a change in evidence.** Reusing an old result after redefining the problem is not continuity; it is a category error.
+2. **Failure is state, not embarrassment.** A negative or inconclusive result should remain inspectable rather than disappear from the interface.
+3. **Honesty can be designed.** Product architecture can make overclaiming easier or harder; interface decisions carry epistemic consequences.
+
+## 8. One-to-one outreach
+
+### English tester invitation
+
+> I have just released EPSILON v2.0, an open-source quantitative decision lab. I am testing one narrow idea: whether keeping the question, failure condition, test configuration, and evidence boundaries together makes a market result harder to misread.
+>
+> Would you be willing to spend five minutes on the guest workflow and tell me the first assumption you would challenge? I am looking for a concrete objection, not a compliment.
+>
+> https://epsilon-livid.vercel.app/landing
+
+### Chinese tester invitation
+
+> 我刚发布了 EPSILON v2.0，一个开源量化决策实验室。我现在想验证一个很具体的问题：把问题、失败条件、测试配置和证据边界放在一起，是否真的能降低用户误读结果的可能性？
+>
+> 如果你愿意花五分钟体验访客流程，我只想请你回答一个问题：**你最先会质疑哪一个假设？** 我更需要具体反对意见，而不是一句表扬。
+>
+> https://epsilon-livid.vercel.app/landing
+
+### Follow-up after feedback
+
+> Thank you. I understood your main objection as: **[restate the objection]**. I am going to test it by **[specific change or experiment]**. If I misunderstood the issue, please correct me before I change the product.
+
+## 9. Long-form article structure
+
+**Working title:** `The Backtest Was Precise. The Question Was Not.`
+
+Chinese title: `回测结果很精确，但问题并不精确`
+
+1. The moment a clean result felt less trustworthy, not more.
+2. Why conventional output-first interfaces encourage over-interpretation.
+3. The design decision: require a claim and rejection rule before testing.
+4. The state problem: when a changed question makes old evidence stale.
+5. The provenance problem: why unknown must remain unknown.
+6. What the controlled synthetic path demonstrates—and what it cannot prove.
+7. What building EPSILON changed in the builder's own way of thinking.
+8. Open question to readers: what assumption would you challenge first?
+
+## 10. Visual asset map
+
+| Use | Asset | Link/path |
+|---|---|---|
+| Link preview / announcement hero | EPSILON social preview | `website/public/social/epsilon-social-preview-v1.jpg` |
+| Short video | 30-second product film | `docs/media/epsilon-demo-30s/epsilon-decision-lab-30s.mp4` |
+| Video thumbnail | Product film poster | `docs/media/epsilon-demo-30s/epsilon-decision-lab-30s-poster.jpg` |
+| Product overview | Landing screenshot | `docs/screenshots/landing.png` |
+| Technical proof | Strategy Lab screenshot | `docs/screenshots/strategy-lab.png` |
+| Canonical downloadable assets | v2.0 GitHub Release | https://github.com/DresdenGman/EPSILON-trading-simulator/releases/tag/v2.0.0 |
+
+Rules:
+
+- Use one hero image and at most one supporting interface image per short post.
+- Use the video when the platform supports native upload; otherwise link the clickable poster to the Release asset.
+- Never use a performance metric as the announcement thumbnail.
+- Keep the product name, subtitle, and core loop consistent across every asset.
+
+## 11. Response library
+
+**“Is this an AI trading tool?”**
+No. Interrogate helps structure critique; it does not predict markets, establish truth, or give investment advice. Public guest sessions use a local heuristic rather than live AI or web retrieval.
+
+**“Are the results based on live or historical market data?”**
+The public guest workflow uses controlled synthetic evidence and labels it accordingly. Historical validity should only be claimed for a run with inspectable data provenance and an executed validation protocol.
+
+**“Does it make profitable strategies?”**
+EPSILON does not claim profitability or market-beating performance. Its present value is the research workflow and evidence discipline.
+
+**“Why not use an existing backtesting library?”**
+EPSILON is not positioned as a replacement for every execution engine. Its focus is the state and interpretation layer around a claim: what was asked, what was submitted, what is known, what failed, and when evidence becomes stale.
+
+**“What would success look like?”**
+Early success means users complete the research loop, identify specific methodological weaknesses, reproduce a test, and return after revising a question—not merely that a post receives views.
+
+## 12. Claims and red lines
+
+Never claim or imply:
+
+- investment advice or a stock recommendation;
+- live trading or brokerage execution;
+- alpha generation or market-beating performance;
+- historical validation from controlled synthetic data;
+- general robustness from one sensitivity test;
+- real-time market data without inspectable provider provenance;
+- that AI predicts markets or decides what is true;
+- user, traffic, retention, or adoption numbers before measuring them.
+
+Preferred correction language:
+
+> My earlier wording was broader than the evidence supports. The current product demonstrates **[verified capability]**, not **[unsupported implication]**. I have corrected the description and preserved the change publicly.
+
+## 13. First seven-day distribution sequence
+
+### Day 1 — release story
+
+Publish the short English or Chinese post with the product film. Ask one question: **What assumption would you challenge first?**
+
+### Days 2–3 — five direct invitations
+
+Send the one-to-one tester message to people likely to give methodological feedback. Record the objection, not just the person's name or reaction.
+
+### Day 4 — technical explanation
+
+Publish the first half of the long-form article or the five-post technical thread. Link to the source and v2.0 Release.
+
+### Day 5 — correction story
+
+Share one specific issue raised by a tester and what changed—or why it did not change. Preserve the reasoning.
+
+### Days 6–7 — launch decision
+
+Use the feedback to decide whether the product is ready for Show HN or needs another focused iteration. Do not interpret impressions as evidence of retention or demand.
+
+## 14. Measurement sheet
+
+Record these after every distribution action:
+
+| Date | Channel | Audience | Post/link | Product visits | Completed loops | Specific objections | GitHub stars | Returning testers | Product change |
+|---|---|---|---|---:|---:|---|---:|---:|---|
+
+The leading indicator is not reach. It is the number and quality of completed research loops, reproducibility attempts, and methodological objections.
+
+## 15. Pre-publish checklist
+
+- [ ] The post uses the canonical product name and stable URL.
+- [ ] Every factual claim is demonstrable in the product or repository.
+- [ ] Synthetic evidence is not described as historical validation.
+- [ ] The post asks for one concrete form of feedback.
+- [ ] The visual shows the research workflow, not an isolated return metric.
+- [ ] The copy reinforces the personal thesis without claiming motives or outcomes that have not been evidenced.
+- [ ] Bracketed placeholders have been replaced.
+- [ ] Product and source links open in a signed-out browser.

--- a/docs/PUBLIC_LAUNCH_KIT.md
+++ b/docs/PUBLIC_LAUNCH_KIT.md
@@ -2,6 +2,8 @@
 
 This is the source of truth for communicating EPSILON publicly. It exists to make the project easier to discover without turning a research product into an overclaim.
 
+For audience-specific bilingual copy, personal-narrative framing, outreach messages, response templates, and the seven-day distribution sequence, use the [EPSILON Communication Pack](COMMUNICATION_PACK.md).
+
 ## The one-sentence position
 
 **EPSILON is a quantitative decision lab that turns a market idea into a falsifiable research loop: observe, test, challenge, and retest.**


### PR DESCRIPTION
## Summary
- add a bilingual EPSILON communication pack built around one consistent builder narrative
- include public, technical, founder, portfolio, and tester-outreach versions
- add verified claims, red lines, response templates, visual guidance, and a seven-day distribution sequence
- link the pack from the README and public launch kit

## Narrative principle
I do not build systems to make answers look more certain. I build systems that make conclusions easier to challenge.

## Validation
- private university-application details are not published
- claims are limited to inspectable product behavior
- Markdown and diff checks pass
- no unrelated working-tree changes are included