### PR TITLE
fix(metrics): make public snapshot automation reliable

### DIFF
--- a/.github/workflows/impact-snapshot.yml
+++ b/.github/workflows/impact-snapshot.yml
@@ -19,17 +19,15 @@ jobs:
           REPOSITORY: ${{ github.repository }}
         run: |
           mkdir -p docs/metrics
-          gh api "repos/${REPOSITORY}/traffic/views" > /tmp/views.json
-          gh api "repos/${REPOSITORY}/traffic/clones" > /tmp/clones.json
           gh api "repos/${REPOSITORY}" > /tmp/repository.json
+          gh api "repos/${REPOSITORY}/releases?per_page=100" > /tmp/releases.json
           curl --fail --silent --show-error "https://epsilonfield.space/api/impact/summary" > /tmp/site.json
           jq -cn \
             --arg captured_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --slurpfile views /tmp/views.json \
-            --slurpfile clones /tmp/clones.json \
             --slurpfile repository /tmp/repository.json \
+            --slurpfile releases /tmp/releases.json \
             --slurpfile site /tmp/site.json \
-            '{captured_at:$captured_at, repository:{stars:$repository[0].stargazers_count,forks:$repository[0].forks_count,views_14d:$views[0].count,unique_visitors_14d:$views[0].uniques,clones_14d:$clones[0].count,unique_cloners_14d:$clones[0].uniques},site:$site[0]}' > docs/metrics/latest.json
+            '{captured_at:$captured_at, repository:{stars:$repository[0].stargazers_count,forks:$repository[0].forks_count,subscribers:$repository[0].subscribers_count,open_issues:$repository[0].open_issues_count,releases:($releases[0]|length),traffic_scope:"owner export only; GitHub Actions cannot access the Traffic API"},site:$site[0]}' > docs/metrics/latest.json
           jq -c . docs/metrics/latest.json >> docs/metrics/history.ndjson
       - name: Preserve changed snapshot
         run: |


### PR DESCRIPTION
GitHub Actions cannot access the repository Traffic API with its integration token. This replaces those calls with public repository metadata, release counts, and the live EPSILON impact API, while explicitly preserving traffic data as an owner-export-only field. The first run failed with HTTP 403; this change makes the daily evidence snapshot auditable and runnable.