### PR TITLE
fix(data): protect the public historical adapter

### DIFF
--- a/instrument/.env.example
+++ b/instrument/.env.example
@@ -3,3 +3,6 @@ MASSIVE_API_KEY=
 
 # Keep false for public releases unless your data license permits public use.
 HISTORICAL_DATA_ENABLED=false
+
+# Match the provider plan. Massive Basic currently permits five calls per minute.
+MASSIVE_CALLS_PER_MINUTE=5

--- a/instrument/app/api/evidence/run/route.ts
+++ b/instrument/app/api/evidence/run/route.ts
@@ -1,6 +1,7 @@
 import { runBacktest, stripLedger, type BacktestConfig, type Bar, type RunConfig, type Strategy } from "../../../../lib/backtest";
 import { describeRule, evidenceDigest, EPSILON_SOFTWARE_REVISION, evaluateEvidence, type FalsificationRule } from "../../../../lib/evidence-contract";
 import { checkRateLimit } from "../../../../lib/rate-limit";
+import { consumeProviderBudget } from "../../../../lib/provider-budget";
 
 export const runtime = "edge";
 
@@ -102,6 +103,9 @@ export async function POST(request: Request) {
     ];
     const fetchFrom = isoShift(input.start, -45);
     const fetchTo = shiftedEnd;
+    if (!(await consumeProviderBudget(universe.length))) {
+      return response({ error: "The shared historical-data budget is busy. Try again after the next minute, or use the deterministic mode." }, 429, { "Retry-After": "60" });
+    }
     const loaded = await Promise.all(universe.map(async (symbol) => [symbol, await loadSymbol(symbol, fetchFrom, fetchTo, apiKey)] as const));
     const series = Object.fromEntries(loaded);
     const computed = runs.map((run) => runBacktest(run, series));

--- a/instrument/app/api/health/route.ts
+++ b/instrument/app/api/health/route.ts
@@ -1,5 +1,7 @@
 export const runtime = "edge";
 
+import { providerBudgetLimit } from "../../../lib/provider-budget";
+
 const DAY = 86_400_000;
 
 function suggestedHistoricalRange(now = Date.now()) {
@@ -18,6 +20,7 @@ export async function GET() {
       historicalAdapter: {
         configured: Boolean(process.env.MASSIVE_API_KEY),
         enabled: process.env.HISTORICAL_DATA_ENABLED === "true",
+        sharedCallBudgetPerMinute: providerBudgetLimit(),
         suggestedRange: suggestedHistoricalRange(),
       },
       rawMarketDataApi: false,

--- a/instrument/drizzle/0001_provider_rate_windows.sql
+++ b/instrument/drizzle/0001_provider_rate_windows.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS provider_rate_windows (
+  bucket TEXT PRIMARY KEY,
+  used INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+PRAGMA optimize;

--- a/instrument/lib/provider-budget.ts
+++ b/instrument/lib/provider-budget.ts
@@ -1,0 +1,34 @@
+import { env } from "cloudflare:workers";
+
+export function providerBudgetLimit() {
+  const configured = Number(process.env.MASSIVE_CALLS_PER_MINUTE ?? "5");
+  return Number.isFinite(configured) ? Math.max(1, Math.min(500, Math.floor(configured))) : 5;
+}
+
+async function ensureProviderBudgetSchema() {
+  await env.DB.prepare(`CREATE TABLE IF NOT EXISTS provider_rate_windows (
+    bucket TEXT PRIMARY KEY,
+    used INTEGER NOT NULL,
+    updated_at TEXT NOT NULL
+  )`).run();
+}
+
+export async function consumeProviderBudget(units: number) {
+  const limit = providerBudgetLimit();
+  if (!Number.isInteger(units) || units < 1 || units > limit) return false;
+  await ensureProviderBudgetSchema();
+  const now = new Date();
+  const bucket = now.toISOString().slice(0, 16);
+  const cutoff = new Date(now.getTime() - 86_400_000).toISOString().slice(0, 16);
+  await env.DB.prepare("DELETE FROM provider_rate_windows WHERE bucket < ?").bind(cutoff).run();
+  const reserved = await env.DB.prepare(`INSERT INTO provider_rate_windows (bucket, used, updated_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(bucket) DO UPDATE SET
+      used = provider_rate_windows.used + excluded.used,
+      updated_at = excluded.updated_at
+    WHERE provider_rate_windows.used + excluded.used <= ?
+    RETURNING used`)
+    .bind(bucket, units, now.toISOString(), limit)
+    .first<{ used: number }>();
+  return Boolean(reserved);
+}


### PR DESCRIPTION
## Outcome\n\nKeeps the live Massive historical-data adapter public without allowing concurrent visitors to exhaust a free or capped provider plan.\n\n- adds an atomic, site-wide D1 reservation window\n- defaults to the current Massive Basic allowance of five calls per minute\n- preserves the secret exclusively on the server\n- returns a clear retry/fallback response when the shared budget is busy\n- publishes the configured budget through the machine-readable health endpoint\n\n## Verification\n\n- production historical request completed successfully before the change\n- `npm run check` and `npm run build` pass in the exact public instrument source\n- no raw market-data redistribution endpoint is exposed