### PR TITLE
fix(data): verify public evidence metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ eggs/
 .eggs/
 lib/
 !website/lib/
+!instrument/lib/
+!instrument/lib/**
 lib64/
 parts/
 sdist/

--- a/docs/COMMUNICATION_PACK.md
+++ b/docs/COMMUNICATION_PACK.md
@@ -86,13 +86,13 @@ Avoid:
 
 Public copy may state that EPSILON:
 
-- has one web workflow: **Market → Strategy Lab → Interrogate**;
-- allows a hypothesis and rejection condition to be recorded before testing;
-- keeps submitted inputs, metrics, trade evidence, and known/unknown provenance boundaries together;
-- marks evidence stale when the subject, hypothesis, or rejection condition changes;
-- preserves the last successful artifact when a later run fails;
-- provides a guest path without requiring an account;
-- labels guest-mode evidence as controlled synthetic simulation;
+- has one public workflow: **Define → Perturb → Challenge**;
+- requires a claim and machine-readable rejection rule before computation;
+- can run adjusted daily historical market data through a server-side Massive adapter;
+- computes one baseline, four atomic perturbations, and one joint stress;
+- exports an evidence artifact containing the configuration, exact outcomes, limitations, provider provenance, source-data fingerprint, stable evidence ID, and full-artifact checksum;
+- provides a deterministic demonstration mode alongside historical evaluation;
+- requires no account for the public laboratory;
 - is open source and preserves its original desktop history in the same repository.
 
 Every public claim should be demonstrable through one of these links:
@@ -111,11 +111,11 @@ Every public claim should be demonstrable through one of these links:
 
 > I built EPSILON around a question that bothered me: when a backtest looks convincing, what would have to be true for it to deserve our trust?
 >
-> EPSILON turns a market idea into a falsifiable loop—observe, define, test, challenge, and retest. The question, configuration, evidence boundaries, and failure condition stay attached to the result.
+> EPSILON turns a market idea into a falsifiable loop. It runs one baseline and five nearby stresses against real historical data, then keeps the rejection rule, assumptions, provenance, failures, and limitations attached to the result.
 >
-> It is open source, and the guest workspace is available without an account. I would value criticism of the research workflow—especially the assumption you would challenge first.
+> It is open source and available without an account. I am looking for one concrete methodological objection: which assumption would you challenge first?
 >
-> Product: https://epsilonfield.space
+> Laboratory: https://epsilonfield.space/lab
 > Source: https://github.com/DresdenGman/EPSILON-trading-simulator
 
 ### Short Chinese post
@@ -137,9 +137,9 @@ Every public claim should be demonstrable through one of these links:
 
 > Hi HN — I originally built EPSILON as a desktop trading simulator. While working on it, I became less interested in producing another performance number and more interested in a harder problem: how quickly a clean result can become detached from the assumptions that produced it.
 >
-> I rebuilt the web product around the lifecycle of a claim. A user selects a market subject, writes a hypothesis and rejection condition, runs a controlled test, and inspects the submitted configuration, result, trade evidence, and known/unknown provenance together. If the question changes, the previous artifact becomes stale rather than being silently reused. A failed run cannot erase the last successful artifact.
+> I rebuilt the web product around the lifecycle of a claim. A user writes a falsifiable claim and rejection condition, chooses historical symbols and a window, and runs one baseline plus five nearby perturbations. The exported artifact keeps the configuration, exact outcomes, limitations, provider provenance, source-data fingerprint, and content checksum together.
 >
-> The public guest path uses clearly labeled browser-local synthetic evidence. It does not claim live data, historical validation, profitability, or investment advice.
+> Historical mode uses adjusted daily bars from Massive. It does not model intraday liquidity, market impact, taxes, borrow constraints, or partial fills, and it makes no claim of profitability or investment advice. A separate deterministic mode remains available for learning the workflow.
 >
 > I would especially value methodological criticism: where does this workflow still make it too easy to over-interpret a result?
 >
@@ -158,7 +158,7 @@ The workflow is simple: Observe → Define → Test → Challenge → Retest. Th
 Missing provenance is not filled with a plausible story. If the provider, sampling, fees, slippage, fill model, or benchmark is unknown, the interface keeps it unknown.
 
 **4/5**
-Guest mode uses controlled browser-local simulation. That demonstrates the workflow; it does not establish historical validity, robustness, profitability, or investment advice.
+Historical mode tests adjusted daily market data. A completed run is evidence for that exact configuration and window, not proof of general robustness, profitability, or investment advice.
 
 **5/5**
 EPSILON v2.0 is open source. I am looking for methodological objections, not applause: what assumption would you challenge first?
@@ -187,7 +187,7 @@ Research-minded students, technical users, and quantitative builders who want an
 Not broader market coverage. The wedge is evidence discipline: the research question, configuration, provenance, output, and challenge history remain connected.
 
 **What is not yet proven?**
-Market demand, retention, real historical validation, and any performance benefit. Early distribution should test whether users value the workflow—not imply those outcomes already exist.
+Market demand, retention, independent reproducibility, general robustness, and any performance benefit. Early distribution should test whether users value and can challenge the workflow—not imply those outcomes already exist.
 
 ## 7. Builder narrative
 
@@ -217,11 +217,11 @@ This framing makes EPSILON one piece of a repeatable intellectual pattern across
 
 ### English tester invitation
 
-> I have just released EPSILON v2.0, an open-source quantitative decision lab. I am testing one narrow idea: whether keeping the question, failure condition, test configuration, and evidence boundaries together makes a market result harder to misread.
+> I have just released a real-data version of EPSILON, an open-source quantitative evidence instrument. I am testing one narrow idea: whether showing a baseline beside nearby changes in costs, window, and universe makes a market conclusion harder to overstate.
 >
-> Would you be willing to spend five minutes on the guest workflow and tell me the first assumption you would challenge? I am looking for a concrete objection, not a compliment.
+> Would you be willing to spend five minutes running one historical experiment and tell me the first assumption you would challenge? I am looking for a concrete objection, not a compliment.
 >
-> https://epsilonfield.space
+> https://epsilonfield.space/lab
 
 ### Chinese tester invitation
 

--- a/docs/PUBLIC_LAUNCH_KIT.md
+++ b/docs/PUBLIC_LAUNCH_KIT.md
@@ -22,8 +22,9 @@ Only use these statements without additional qualification:
 - A user records a claim and machine-readable rejection rule before computation.
 - One baseline, four atomic perturbations, and one joint stress remain visible together.
 - Every completed run can be exported as a JSON evidence artifact with configuration, provenance, exact outcomes, limitations, and SHA-256 fingerprints.
-- The public instrument requires no login and clearly distinguishes deterministic demonstration evidence from configured historical evaluation.
-- Anonymous impact measurement records workflow events only; it does not store names, emails, claims, portfolio information, or IP-derived affiliation.
+- Historical evaluation uses adjusted daily bars from the server-side Massive adapter; deterministic demonstration remains a separate, labeled mode.
+- The public instrument requires no login.
+- Public measurement separates anonymous browser signals from server-verified historical experiments and stores no account identifiers.
 - EPSILON is open source and its original desktop history remains in this repository.
 
 ## Claims that require evidence first
@@ -32,9 +33,9 @@ Do not use these until real user evidence exists:
 
 - “Improves investment performance” or “finds alpha”
 - “AI-powered investment advice”
-- “Live market data” or “institutional-grade data”
+- “Real-time market data,” “institutional-grade data,” or unrestricted market-data coverage
 - Any user, traffic, accuracy, profitability, or adoption number
-- Any statement implying a result is historical validation, statistical significance, or general robustness
+- Any statement implying one historical result establishes statistical significance, profitability, or general robustness
 
 ## Links
 
@@ -100,9 +101,9 @@ Use feedback to decide whether the next step is a community post, a Show HN subm
 
 > Hi HN — I originally built EPSILON as a trading simulator. I rebuilt the web product around a narrower problem: backtests often show a result without making it clear which assumptions, missing data, and rejection conditions still bound that result.
 >
-> EPSILON has one workflow: choose a market subject, write a hypothesis and falsification condition, run a controlled test, inspect the stored configuration and provenance, then challenge the interpretation. If the subject or question changes, the earlier artifact becomes stale rather than being overwritten.
+> EPSILON has one workflow: write a claim and falsification condition, choose historical symbols and a window, run one baseline plus five nearby perturbations, inspect the exact configuration and provenance, then challenge the interpretation.
 >
-> The guest mode uses a clearly labeled browser-local synthetic simulation. It does not claim live data, historical validity, profitability, or investment advice.
+> Historical mode uses adjusted daily bars from Massive. The artifact records a source-data fingerprint and checksum, but it does not model intraday liquidity, market impact, taxes, borrow constraints, or partial fills. It makes no claim of profitability or investment advice.
 >
 > I would especially value feedback from people who build or use backtesting tools: where does this evidence workflow still fail to make the limits of a result clear?
 >

--- a/instrument/app/api/evidence/run/route.ts
+++ b/instrument/app/api/evidence/run/route.ts
@@ -1,7 +1,10 @@
 import { runBacktest, stripLedger, type BacktestConfig, type Bar, type RunConfig, type Strategy } from "../../../../lib/backtest";
-import { describeRule, evidenceDigest, EPSILON_SOFTWARE_REVISION, evaluateEvidence, type FalsificationRule } from "../../../../lib/evidence-contract";
+import { createEvidenceArtifact, describeRule, evidenceDigest, EVIDENCE_LIMITATIONS, EPSILON_SOFTWARE_REVISION, evaluateEvidence, type FalsificationRule } from "../../../../lib/evidence-contract";
 import { checkRateLimit } from "../../../../lib/rate-limit";
 import { consumeProviderBudget } from "../../../../lib/provider-budget";
+import { missingProviderSymbols } from "../../../../lib/provider-cache";
+import { readBoundedJson, RequestBodyError } from "../../../../lib/http";
+import { recordVerifiedHistoricalRun } from "../../../../lib/impact";
 
 export const runtime = "edge";
 
@@ -33,8 +36,6 @@ function pruneCache() {
 
 async function loadSymbol(symbol: string, from: string, to: string, apiKey: string) {
   const cacheKey = `${symbol}:${from}:${to}`;
-  const cached = marketCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) return cached.bars;
   const url = new URL(`https://api.massive.com/v2/aggs/ticker/${encodeURIComponent(symbol)}/range/1/day/${from}/${to}`);
   url.searchParams.set("adjusted", "true");
   url.searchParams.set("sort", "asc");
@@ -53,6 +54,11 @@ async function loadSymbol(symbol: string, from: string, to: string, apiKey: stri
   return bars;
 }
 
+function cachedSymbol(symbol: string, from: string, to: string) {
+  const cached = marketCache.get(`${symbol}:${from}:${to}`);
+  return cached && cached.expiresAt > Date.now() ? cached.bars : null;
+}
+
 function validRule(value: unknown): value is FalsificationRule {
   if (!value || typeof value !== "object") return false;
   const rule = value as Record<string, unknown>;
@@ -64,13 +70,15 @@ export async function POST(request: Request) {
   const apiKey = process.env.MASSIVE_API_KEY;
   if (!apiKey) return response({ error: "Historical data is not configured." }, 503);
   if (!request.headers.get("content-type")?.toLowerCase().includes("application/json")) return response({ error: "Content-Type must be application/json." }, 415);
-  if (Number(request.headers.get("content-length") ?? 0) > 20_000) return response({ error: "Request body is too large." }, 413);
   const limit = checkRateLimit(request, "evidence-run", 6);
   if (limit.limited) return response({ error: "Historical evidence limit reached. Try again shortly." }, 429, { "Retry-After": String(limit.retryAfter) });
 
   let input: Partial<BacktestConfig> & { claim?: string; falsificationRule?: unknown };
-  try { input = await request.json() as typeof input; }
-  catch { return response({ error: "Request body must be valid JSON." }, 400); }
+  try { input = await readBoundedJson<typeof input>(request, 20_000); }
+  catch (error) {
+    if (error instanceof RequestBodyError) return response({ error: error.message }, error.status);
+    return response({ error: "Request body must be valid JSON." }, 400);
+  }
 
   const claim = String(input.claim ?? "").trim();
   const universe = Array.isArray(input.universe) ? [...new Set(input.universe.map((item) => String(item).trim().toUpperCase()))] : [];
@@ -103,10 +111,12 @@ export async function POST(request: Request) {
     ];
     const fetchFrom = isoShift(input.start, -45);
     const fetchTo = shiftedEnd;
-    if (!(await consumeProviderBudget(universe.length))) {
+    const cached = new Map(universe.map((symbol) => [symbol, cachedSymbol(symbol, fetchFrom, fetchTo)]));
+    const misses = missingProviderSymbols(universe, (symbol) => cached.get(symbol));
+    if (misses.length && !(await consumeProviderBudget(misses.length))) {
       return response({ error: "The shared historical-data budget is busy. Try again after the next minute, or use the deterministic mode." }, 429, { "Retry-After": "60" });
     }
-    const loaded = await Promise.all(universe.map(async (symbol) => [symbol, await loadSymbol(symbol, fetchFrom, fetchTo, apiKey)] as const));
+    const loaded = await Promise.all(universe.map(async (symbol) => [symbol, cached.get(symbol) ?? await loadSymbol(symbol, fetchFrom, fetchTo, apiKey)] as const));
     const series = Object.fromEntries(loaded);
     const computed = runs.map((run) => runBacktest(run, series));
     const baselineLedger = computed[0].ledger;
@@ -124,8 +134,11 @@ export async function POST(request: Request) {
       verdict: evaluateEvidence(evidenceRuns, rule),
       runs: evidenceRuns,
       baselineLedger,
+      limitations: [...EVIDENCE_LIMITATIONS],
     };
-    return response({ ...core, generatedAt: new Date().toISOString(), artifactHash: await evidenceDigest(core) });
+    const artifact = await createEvidenceArtifact(core);
+    await recordVerifiedHistoricalRun(artifact.evidenceId, artifact.artifactHash, artifact.generatedAt).catch(() => undefined);
+    return response(artifact);
   } catch (error) {
     const message = error instanceof Error ? error.message : "historical_evidence_failed";
     if (message === "provider_access_window") return response({ error: "This historical window is outside the currently available data range. Choose more recent dates." }, 422);

--- a/instrument/app/api/impact/events/route.ts
+++ b/instrument/app/api/impact/events/route.ts
@@ -1,4 +1,6 @@
-import { ensureImpactSchema, impactDb, isImpactEvent } from "../../../../lib/impact";
+import { consumeImpactBudget, impactDb, isClientImpactEvent, normalizeImpactSource } from "../../../../lib/impact";
+import { readBoundedJson, RequestBodyError } from "../../../../lib/http";
+import { checkRateLimit } from "../../../../lib/rate-limit";
 
 type EventPayload = {
   event?: unknown;
@@ -14,25 +16,32 @@ function cleanText(value: unknown, max: number, fallback = "unknown") {
 }
 
 export async function POST(request: Request) {
+  if (!request.headers.get("content-type")?.toLowerCase().includes("application/json")) {
+    return Response.json({ error: "Content-Type must be application/json." }, { status: 415 });
+  }
+  const limit = checkRateLimit(request, "impact-events", 12);
+  if (limit.limited) return Response.json({ error: "Measurement limit reached." }, { status: 429, headers: { "Retry-After": String(limit.retryAfter) } });
+
   let payload: EventPayload;
   try {
-    payload = await request.json() as EventPayload;
-  } catch {
+    payload = await readBoundedJson<EventPayload>(request, 2_048);
+  } catch (error) {
+    if (error instanceof RequestBodyError) return Response.json({ error: error.message }, { status: error.status });
     return Response.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  if (!isImpactEvent(payload.event)) return Response.json({ error: "Unsupported event" }, { status: 400 });
+  if (!isClientImpactEvent(payload.event)) return Response.json({ error: "Unsupported client event" }, { status: 400 });
   const sessionId = cleanText(payload.sessionId, 64, "");
   if (!/^[a-f0-9-]{20,64}$/i.test(sessionId)) return Response.json({ error: "Invalid session" }, { status: 400 });
 
-  const artifactHash = cleanText(payload.artifactHash, 64, "");
+  const artifactHash = "";
   const createdAt = new Date().toISOString();
   const day = createdAt.slice(0, 10);
   const uniqueUnit = artifactHash || (payload.event === "site_visit" || payload.event === "lab_opened" ? "session" : day);
   const dedupeKey = `${payload.event}:${sessionId}:${uniqueUnit}`;
 
   try {
-    await ensureImpactSchema();
+    if (!(await consumeImpactBudget())) return Response.json({ error: "Measurement is busy." }, { status: 429, headers: { "Retry-After": "60" } });
     await impactDb().prepare(`INSERT OR IGNORE INTO impact_events
       (id, dedupe_key, event_name, session_id, source, path, artifact_hash, mode, created_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
@@ -41,10 +50,10 @@ export async function POST(request: Request) {
         dedupeKey,
         payload.event,
         sessionId,
-        cleanText(payload.source, 80, "direct"),
-        cleanText(payload.path, 120, "/"),
+        normalizeImpactSource(payload.source),
+        cleanText(payload.path, 120, "/").startsWith("/") ? cleanText(payload.path, 120, "/") : "/",
         artifactHash || null,
-        cleanText(payload.mode, 32, "") || null,
+        null,
         createdAt,
       ).run();
     return Response.json({ recorded: true }, { status: 202 });

--- a/instrument/app/api/impact/summary/route.ts
+++ b/instrument/app/api/impact/summary/route.ts
@@ -1,29 +1,20 @@
-import { ensureImpactSchema, impactDb } from "../../../../lib/impact";
+import { impactDb, pruneImpactEvents } from "../../../../lib/impact";
 
 type MetricRow = { event_name: string; events: number; sessions: number };
-type SourceRow = { source: string; sessions: number; lab_sessions: number };
-
 export async function GET() {
   try {
-    await ensureImpactSchema();
-    const [metricResult, sourceResult] = await impactDb().batch([
-      impactDb().prepare(`SELECT event_name,
+    const retainedAfter = await pruneImpactEvents();
+    const metricResult = await impactDb().prepare(`SELECT event_name,
         COUNT(*) AS events,
         COUNT(DISTINCT session_id) AS sessions
-        FROM impact_events GROUP BY event_name`),
-      impactDb().prepare(`SELECT source,
-        COUNT(DISTINCT session_id) AS sessions,
-        COUNT(DISTINCT CASE WHEN event_name = 'lab_opened' THEN session_id END) AS lab_sessions
         FROM impact_events
-        WHERE event_name IN ('site_visit', 'lab_opened')
-        GROUP BY source ORDER BY lab_sessions DESC, sessions DESC LIMIT 20`),
-    ]);
+        WHERE event_name IN ('site_visit', 'lab_opened', 'challenge_opened', 'reproduce_opened', 'verified_historical_run')
+          AND created_at >= ?
+        GROUP BY event_name`).bind(retainedAfter).all();
     const rows = (metricResult.results ?? []) as unknown as MetricRow[];
-    const sourceRows = (sourceResult.results ?? []) as unknown as SourceRow[];
     const metrics = Object.fromEntries(rows.map((row) => [row.event_name, { events: Number(row.events), sessions: Number(row.sessions) }]));
-    const sources = sourceRows.map((row) => ({ source: row.source, sessions: Number(row.sessions), labSessions: Number(row.lab_sessions) }));
-    return Response.json({ status: "live", updatedAt: new Date().toISOString(), metrics, sources }, { headers: { "Cache-Control": "public, max-age=60, s-maxage=300" } });
+    return Response.json({ status: "live", updatedAt: new Date().toISOString(), metrics, measurement: { verified: ["verified_historical_run"], unverifiedSignals: ["site_visit", "lab_opened", "challenge_opened", "reproduce_opened"], retentionDays: 90, countingWindow: "rolling" } }, { headers: { "Cache-Control": "public, max-age=60, s-maxage=300" } });
   } catch {
-    return Response.json({ status: "initializing", updatedAt: new Date().toISOString(), metrics: {}, sources: [] }, { status: 200 });
+    return Response.json({ status: "initializing", updatedAt: new Date().toISOString(), metrics: {}, measurement: { verified: [], unverifiedSignals: [], retentionDays: 90 } }, { status: 200 });
   }
 }

--- a/instrument/app/impact/page.tsx
+++ b/instrument/app/impact/page.tsx
@@ -32,21 +32,21 @@ export default function ImpactPage() {
 
       <section className="impact-intro">
         <div><p className="eyebrow">Public impact record / measured conservatively</p><h1>Reach is visible.<br /><span>Impact must be earned.</span></h1></div>
-        <p>EPSILON separates anonymous product activity from independently reviewable contribution. A page view is reach. A completed evidence field is use. A substantive external challenge is impact only after it remains publicly inspectable.</p>
+        <p>EPSILON separates anonymous browser signals from server-verified research use and independently reviewable contribution. A page view is unverified reach. A historical evidence run is counted only after the server completes it. A substantive external challenge becomes impact only when it remains publicly inspectable.</p>
       </section>
 
       <section className="impact-scorecard" aria-label="Anonymous product activity">
-        <article><span>Anonymous research sessions</span><strong>{value(summary, "lab_opened")}</strong><p>Distinct browser sessions that opened the instrument.</p></article>
-        <article><span>Evidence fields completed</span><strong>{value(summary, "evidence_completed", "events")}</strong><p>Deduplicated machine-readable artifacts generated.</p></article>
-        <article><span>Artifacts exported</span><strong>{value(summary, "evidence_exported", "events")}</strong><p>Evidence files downloaded for inspection or reuse.</p></article>
-        <article><span>Method challenges opened</span><strong>{value(summary, "challenge_opened")}</strong><p>Sessions that continued to the external review channel.</p></article>
+        <article><span>Anonymous lab signals</span><strong>{value(summary, "lab_opened")}</strong><p>Deduplicated, unverified browser sessions that opened the instrument.</p></article>
+        <article><span>Verified historical experiments</span><strong>{value(summary, "verified_historical_run", "events")}</strong><p>Unique real-data evidence configurations completed and recorded by the server.</p></article>
+        <article><span>Challenge-link signals</span><strong>{value(summary, "challenge_opened")}</strong><p>Unverified sessions that opened the external review channel.</p></article>
+        <article><span>Public reproductions</span><strong>0</strong><p>Reserved for independently linkable reproduction records, never browser clicks.</p></article>
       </section>
 
       <section className="impact-layers">
         <div><p className="eyebrow">Evidence hierarchy</p><h2>Not every number means the same thing.</h2></div>
         <ol>
           <li><span>01 / Reach</span><div><h3>Someone encountered the work.</h3><p>Visits, impressions, and video views are useful distribution diagnostics. They are not counted as adoption or educational impact.</p></div></li>
-          <li><span>02 / Use</span><div><h3>Someone completed a research action.</h3><p>Opening the laboratory, completing an evidence field, and exporting an artifact are measured as distinct anonymous actions.</p></div></li>
+          <li><span>02 / Use</span><div><h3>The server completed a research action.</h3><p>Only completed historical-data evidence runs are shown as verified product use. Browser openings and link clicks remain explicitly unverified signals.</p></div></li>
           <li><span>03 / External challenge</span><div><h3>Someone tested the method itself.</h3><p>A review counts only when a real person identifies a specific assumption, evidence gap, interpretation risk, or product weakness in a publicly linkable record.</p></div></li>
           <li><span>04 / Change</span><div><h3>The criticism altered the work.</h3><p>Accepted challenges link to the resulting experiment, issue, correction, or product change. Unfavorable findings remain visible.</p></div></li>
         </ol>
@@ -54,7 +54,7 @@ export default function ImpactPage() {
 
       <section className="impact-challenge">
         <div><p className="eyebrow">Falsification challenge / open</p><h2>Find the assumption<br />we failed to expose.</h2></div>
-        <div><p>The most valuable contribution is not praise. Run one evidence field, identify one weakness, and leave a challenge another person can inspect.</p><div className="impact-action-stack"><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/discussions/8" target="_blank" rel="noreferrer" className="primary-button" onClick={() => void recordImpactEvent("challenge_opened")}>Open the challenge protocol <span>↗</span></a><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/issues/new?template=reproduction-report.yml" target="_blank" rel="noreferrer" className="text-link" onClick={() => void recordImpactEvent("reproduce_opened")}>File an independent reproduction →</a></div><p className="impact-integrity">No purchased traffic · no coordinated votes · no investment claims · no personal data collected · session identifiers are temporary and anonymous.</p></div>
+        <div><p>The most valuable contribution is not praise. Run one evidence field, identify one weakness, and leave a challenge another person can inspect.</p><div className="impact-action-stack"><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/discussions/8" target="_blank" rel="noreferrer" className="primary-button" onClick={() => void recordImpactEvent("challenge_opened")}>Open the challenge protocol <span>↗</span></a><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/issues/new?template=reproduction-report.yml" target="_blank" rel="noreferrer" className="text-link" onClick={() => void recordImpactEvent("reproduce_opened")}>File an independent reproduction →</a></div><p className="impact-integrity">No purchased traffic · no coordinated votes · no investment claims · no account identifiers · coarse source categories only · rolling 90-day measurement window.</p></div>
       </section>
 
       <footer><span>{summary.status === "live" ? "Measurement live" : "Measurement initializing"}{summary.updatedAt ? ` · ${new Date(summary.updatedAt).toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" })}` : ""}</span><div><Link href="/">Home →</Link><Link href="/lab">Run an evidence field →</Link></div></footer>

--- a/instrument/app/lab/page.tsx
+++ b/instrument/app/lab/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { stripLedger, type LedgerEntry, type Strategy } from "../../lib/backtest";
-import { describeRule, evidenceDigest, EPSILON_SOFTWARE_REVISION, evaluateEvidence, type EvidenceRun, type EvidenceVerdict, type FalsificationRule, type Metric, type Operator } from "../../lib/evidence-contract";
+import { createEvidenceArtifact, describeRule, evidenceDigest, EVIDENCE_LIMITATIONS, EPSILON_SOFTWARE_REVISION, evaluateEvidence, type EvidenceRun, type EvidenceVerdict, type FalsificationRule, type Metric, type Operator } from "../../lib/evidence-contract";
 import { makeSyntheticRuns } from "../../lib/synthetic";
 import { recordImpactEvent } from "../../components/impact-tracker";
 
@@ -11,6 +11,8 @@ type Evidence = {
   format: "epsilon.evidence.v2";
   generatedAt: string;
   artifactHash: string;
+  evidenceId: string;
+  integrity: { algorithm: "SHA-256"; scope: string; authenticity: string };
   softwareRevision: string;
   claim: string;
   falsification: string;
@@ -21,6 +23,7 @@ type Evidence = {
   verdict: EvidenceVerdict;
   runs: EvidenceRun[];
   baselineLedger: LedgerEntry[];
+  limitations: string[];
 };
 
 const metricLabels: Record<Metric, string> = { net_return: "Net total return", max_drawdown: "Maximum drawdown", sharpe: "Annualized Sharpe" };
@@ -106,10 +109,9 @@ export default function LabPage() {
           verdict: evaluateEvidence(runs, rule),
           runs,
           baselineLedger,
+          limitations: [...EVIDENCE_LIMITATIONS],
         };
-        const artifactHash = await evidenceDigest(core);
-        setEvidence({ ...core, generatedAt: new Date().toISOString(), artifactHash });
-        void recordImpactEvent("evidence_completed", { artifactHash, mode: "controlled-synthetic" });
+        setEvidence(await createEvidenceArtifact(core));
         setLocked(true);
         setStatus("Evidence field complete / six controlled computations");
         return;
@@ -119,7 +121,6 @@ export default function LabPage() {
       const payload = await result.json() as Evidence & { error?: string };
       if (!result.ok) throw new Error(payload.error ?? "Historical evidence failed.");
       setEvidence(payload);
-      void recordImpactEvent("evidence_completed", { artifactHash: payload.artifactHash, mode: "historical-market-data" });
       setLocked(true);
       setStatus("Historical evidence complete / six server-side computations");
     } catch (error) {
@@ -138,14 +139,12 @@ export default function LabPage() {
     anchor.download = `epsilon-${evidence.artifactHash.slice(0, 12)}.json`;
     anchor.click();
     URL.revokeObjectURL(url);
-    void recordImpactEvent("evidence_exported", { artifactHash: evidence.artifactHash, mode: evidence.mode });
   }
 
   async function copySummary() {
     if (!evidence) return;
     await navigator.clipboard.writeText(`EPSILON ${evidence.verdict.verdict.toUpperCase()} · ${evidence.verdict.survivalCount}/${evidence.verdict.testedCount} perturbations survived · ${metricLabels[evidence.falsificationRule.metric]} worst case ${displayMetric(evidence.verdict.worstCase, evidence.falsificationRule.metric)} · artifact ${evidence.artifactHash.slice(0, 12)}`);
     setCopied(true);
-    void recordImpactEvent("summary_copied", { artifactHash: evidence.artifactHash, mode: evidence.mode });
   }
 
   function editExperiment() {
@@ -170,7 +169,7 @@ export default function LabPage() {
 
       <div className="lab-grid" id="experiment">
         <section className="setup-panel" aria-label="Experiment setup">
-          <div className="panel-title"><div><p className="eyebrow">01 / Define</p><h2>One claim. One rejection rule.</h2></div><span className={`mode-pill ${dataMode === "historical" ? "mode-live" : ""}`}>{dataMode === "synthetic" ? "Demonstration" : "Historical / live"}</span></div>
+          <div className="panel-title"><div><p className="eyebrow">01 / Define</p><h2>One claim. One rejection rule.</h2></div><span className={`mode-pill ${dataMode === "historical" ? "mode-live" : ""}`}>{dataMode === "synthetic" ? "Demonstration" : "Historical / real data"}</span></div>
           <label>Data mode<select disabled={controlsDisabled} value={dataMode} onChange={(event) => setDataMode(event.target.value as "synthetic" | "historical")}><option value="historical" disabled={!historicalAvailable}>Historical market data{historicalAvailable ? " · available" : " · unavailable"}</option><option value="synthetic">Deterministic demonstration</option></select></label>
           <p className="field-note">{dataMode === "historical" ? "Adjusted daily bars are fetched server-side; the provider credential never enters the browser." : "A transparent deterministic sample for learning the workflow—not empirical market evidence."}</p>
           <label>Falsifiable claim<textarea disabled={controlsDisabled} maxLength={240} value={claim} onChange={(event) => setClaim(event.target.value)} rows={3} /></label>
@@ -204,8 +203,8 @@ export default function LabPage() {
               <figure className="lab-chart"><figcaption><span>Atomic and joint stresses, visible consequences.</span><span>Normalized equity</span></figcaption><svg viewBox="0 0 640 210" aria-labelledby="lab-chart-title"><title id="lab-chart-title">Normalized baseline and perturbation equity paths</title>{[40,90,140,190].map((y) => <line key={y} x1="0" y1={y} x2="640" y2={y} className="grid-line" />)}{evidence.runs.map((run) => <polyline key={run.id} points={polyline(run.path)} fill="none" stroke={run.color} strokeWidth={run.id === "baseline" ? 2.5 : 1.5} vectorEffect="non-scaling-stroke" />)}</svg></figure>
               <div className="table-scroll"><table className="result-table"><caption className="sr-only">Exact baseline and perturbation outcomes</caption><thead><tr><th>Run</th><th>Changed input</th><th>Return</th><th>Sharpe</th><th>Drawdown</th><th>Cost</th></tr></thead><tbody>{evidence.runs.map((run) => <tr key={run.id}><th scope="row"><i style={{ background: run.color }} />{run.label}</th><td>{run.changed}</td><td><strong>{displayMetric(run.returnPct, "net_return")}</strong></td><td>{run.sharpe.toFixed(3)}</td><td>{run.drawdown.toFixed(2)}%</td><td>{run.costPct.toFixed(3)}%</td></tr>)}</tbody></table></div>
               <div className="evidence-metrics"><div><span>Worst tested {metricLabels[evidence.falsificationRule.metric]}</span><strong>{displayMetric(evidence.verdict.worstCase, evidence.falsificationRule.metric)}</strong></div><div><span>Worst threshold margin</span><strong>{displayMetric(evidence.verdict.worstMargin, evidence.falsificationRule.metric)}</strong></div><div><span>Largest sensitivity</span><strong>{evidence.verdict.largestSensitivity ? `${evidence.verdict.largestSensitivity.label} ${evidence.verdict.largestSensitivity.delta > 0 ? "+" : ""}${evidence.verdict.largestSensitivity.delta.toFixed(2)}` : "—"}</strong></div><div><span>Baseline observations</span><strong>{evidence.runs[0].observations}</strong></div></div>
-              <div className="artifact-proof"><div><span>Artifact fingerprint</span><code>{evidence.artifactHash.slice(0, 24)}</code></div><div><span>Data fingerprint</span><code>{evidence.provenance.dataFingerprint.slice(0, 24)}</code></div><p>{evidence.provenance.timing}</p></div>
-              <div className="artifact-actions"><p>{evidence.mode === "historical-market-data" ? `Adjusted daily bars · ${evidence.provenance.provider} · ${evidence.provenance.symbols.join(", ")}` : "Deterministic demonstration arithmetic"} · research use only · not investment advice</p><div><button onClick={copySummary}>{copied ? "Copied ✓" : "Copy summary"}</button><button onClick={downloadEvidence}>Download evidence ↓</button><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/discussions/8" target="_blank" rel="noreferrer" onClick={() => void recordImpactEvent("challenge_opened", { artifactHash: evidence.artifactHash, mode: evidence.mode })}>Challenge the method ↗</a></div></div>
+              <div className="artifact-proof"><div><span>Artifact checksum</span><code>{evidence.artifactHash.slice(0, 24)}</code></div><div><span>Data fingerprint</span><code>{evidence.provenance.dataFingerprint.slice(0, 24)}</code></div><p>{evidence.provenance.timing} Checksum is not a digital signature.</p></div>
+              <div className="artifact-actions"><p>{evidence.mode === "historical-market-data" ? `Adjusted daily bars · ${evidence.provenance.provider} · ${evidence.provenance.symbols.join(", ")}` : "Deterministic demonstration arithmetic"} · research use only · not investment advice</p><div><button onClick={copySummary}>{copied ? "Copied ✓" : "Copy summary"}</button><button onClick={downloadEvidence}>Download evidence ↓</button><a href="https://github.com/DresdenGman/EPSILON-trading-simulator/discussions/8" target="_blank" rel="noreferrer" onClick={() => void recordImpactEvent("challenge_opened")}>Challenge the method ↗</a></div></div>
             </article>
           )}
         </section>

--- a/instrument/app/status/page.tsx
+++ b/instrument/app/status/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 const checks = [
   ["Evidence engine", "Operational", "Baseline + four atomic perturbations + one joint execution stress"],
   ["Rejection rule", "Operational", "Machine-evaluable metric, operator, threshold, and required scope"],
-  ["Portable artifact", "Operational", "epsilon.evidence.v2 JSON with calculation and data fingerprints"],
+  ["Portable artifact", "Operational", "epsilon.evidence.v2 JSON with calculation checksum and data fingerprint"],
   ["Execution timing", "Documented", "Signals use information through the prior close; positions apply to the next return"],
   ["Real-capital execution", "Not connected", "Research instrument only; no orders, brokerage, or custody"],
 ];
@@ -41,7 +41,7 @@ export default function StatusPage() {
           <article><span>01</span><h3>Pre-register</h3><p>A claim is paired with a metric, comparison operator, threshold, and perturbation scope before computation.</p></article>
           <article><span>02</span><h3>Lag signals</h3><p>Historical strategies use only information available through the prior close. This prevents same-period look-ahead.</p></article>
           <article><span>03</span><h3>Perturb locally</h3><p>Four one-factor runs isolate sensitivity; one joint stress exposes execution interactions. Survival is evidence of local robustness, not proof.</p></article>
-          <article><span>04</span><h3>Keep the trail</h3><p>The export includes configuration, exact outcomes, baseline ledger, provider provenance, limitations, and deterministic fingerprints.</p></article>
+          <article><span>04</span><h3>Keep the trail</h3><p>The export includes configuration, exact outcomes, baseline ledger, provider provenance, limitations, and a deterministic checksum. The checksum detects changes; it is not a signature or proof of origin.</p></article>
         </div>
       </section>
 

--- a/instrument/components/impact-tracker.tsx
+++ b/instrument/components/impact-tracker.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 
-export type ImpactEvent = "site_visit" | "lab_opened" | "evidence_completed" | "evidence_exported" | "summary_copied" | "challenge_opened" | "reproduce_opened";
+export type ImpactEvent = "site_visit" | "lab_opened" | "challenge_opened" | "reproduce_opened";
 
 const SESSION_KEY = "epsilon_impact_session_v1";
 const SOURCE_KEY = "epsilon_impact_source_v1";
@@ -19,10 +19,12 @@ function sourceLabel() {
   const existing = window.sessionStorage.getItem(SOURCE_KEY);
   if (existing) return existing;
   const query = new URLSearchParams(window.location.search);
-  const campaignSource = query.get("utm_source")?.slice(0, 48);
+  const aliases: Record<string, string> = { twitter: "x", x: "x", github: "github", stocktwits: "stocktwits", linkedin: "linkedin", reddit: "reddit", youtube: "youtube", producthunt: "producthunt", substack: "substack", email: "email", school: "school" };
+  const campaignSource = query.get("utm_source")?.trim().toLowerCase();
   if (campaignSource) {
-    window.sessionStorage.setItem(SOURCE_KEY, campaignSource);
-    return campaignSource;
+    const source = aliases[campaignSource] ?? "other";
+    window.sessionStorage.setItem(SOURCE_KEY, source);
+    return source;
   }
   if (!document.referrer) {
     window.sessionStorage.setItem(SOURCE_KEY, "direct");
@@ -30,7 +32,7 @@ function sourceLabel() {
   }
   try {
     const hostname = new URL(document.referrer).hostname;
-    const source = hostname === window.location.hostname ? "internal" : hostname.slice(0, 80);
+    const source = hostname === window.location.hostname ? "internal" : hostname.endsWith("github.com") ? "github" : hostname.endsWith("stocktwits.com") ? "stocktwits" : hostname.endsWith("linkedin.com") ? "linkedin" : hostname.endsWith("reddit.com") ? "reddit" : hostname.endsWith("youtube.com") || hostname.endsWith("youtu.be") ? "youtube" : "other";
     window.sessionStorage.setItem(SOURCE_KEY, source);
     return source;
   } catch {
@@ -41,7 +43,6 @@ function sourceLabel() {
 
 export async function recordImpactEvent(
   event: ImpactEvent,
-  details: { artifactHash?: string; mode?: string } = {},
 ) {
   if (typeof window === "undefined") return;
   const payload = {
@@ -49,8 +50,6 @@ export async function recordImpactEvent(
     sessionId: sessionId(),
     source: sourceLabel(),
     path: window.location.pathname.slice(0, 120),
-    artifactHash: details.artifactHash?.slice(0, 64),
-    mode: details.mode?.slice(0, 32),
   };
   try {
     await fetch("/api/impact/events", {

--- a/instrument/drizzle/0002_impact_guards.sql
+++ b/instrument/drizzle/0002_impact_guards.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS impact_rate_windows (
+  bucket TEXT PRIMARY KEY,
+  used INTEGER NOT NULL,
+  updated_at TEXT NOT NULL
+);

--- a/instrument/lib/backtest.ts
+++ b/instrument/lib/backtest.ts
@@ -1,0 +1,105 @@
+import type { EvidenceRun } from "./evidence-contract";
+
+export type Bar = { timestamp: number; close: number };
+export type Strategy = "Buy & Hold" | "Moving Average (20-day)" | "Momentum (2%)";
+export type BacktestConfig = { strategy: Strategy; start: string; end: string; universe: string[]; fee: number; slippage: number };
+export type RunConfig = BacktestConfig & { id: string; label: string; changed: string; color: string };
+export type LedgerEntry = { date: string; grossReturn: number; netReturn: number; turnover: number; executionCost: number; activePositions: number };
+
+export function stripLedger(run: EvidenceRun & { ledger: LedgerEntry[] }): EvidenceRun {
+  const { ledger, ...evidenceRun } = run;
+  void ledger;
+  return evidenceRun;
+}
+
+function signal(strategy: Strategy, closes: number[], index: number) {
+  if (strategy === "Buy & Hold") return 1;
+  if (index < 20) return 0;
+  if (strategy === "Moving Average (20-day)") {
+    const history = closes.slice(index - 20, index);
+    const average = history.reduce((sum, value) => sum + value, 0) / history.length;
+    return closes[index - 1] > average ? 1 : 0;
+  }
+  return closes[index - 1] / closes[index - 20] - 1 > 0.02 ? 1 : 0;
+}
+
+function sharedDates(config: RunConfig, series: Record<string, Bar[]>) {
+  const start = Date.parse(`${config.start}T00:00:00Z`);
+  const end = Date.parse(`${config.end}T23:59:59Z`);
+  const counts = new Map<number, number>();
+  for (const symbol of config.universe) {
+    for (const bar of series[symbol] ?? []) counts.set(bar.timestamp, (counts.get(bar.timestamp) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([timestamp, count]) => count === config.universe.length && timestamp >= start && timestamp <= end)
+    .map(([timestamp]) => timestamp)
+    .sort((left, right) => left - right);
+}
+
+export function runBacktest(config: RunConfig, series: Record<string, Bar[]>): EvidenceRun & { ledger: LedgerEntry[] } {
+  const dates = sharedDates(config, series);
+  const indexes = Object.fromEntries(config.universe.map((symbol) => [symbol, new Map(series[symbol].map((bar, index) => [bar.timestamp, index]))]));
+  const closes = Object.fromEntries(config.universe.map((symbol) => [symbol, series[symbol].map((bar) => bar.close)]));
+  const previousPosition: Record<string, number> = {};
+  const ledger: LedgerEntry[] = [];
+  const path = [100];
+
+  for (const timestamp of dates) {
+    let gross = 0;
+    let net = 0;
+    let turnover = 0;
+    let executionCost = 0;
+    let activePositions = 0;
+    let complete = true;
+    for (const symbol of config.universe) {
+      const index = indexes[symbol].get(timestamp);
+      if (index === undefined || index < 1) { complete = false; break; }
+      const symbolCloses = closes[symbol];
+      const position = signal(config.strategy, symbolCloses, index);
+      const marketReturn = symbolCloses[index] / symbolCloses[index - 1] - 1;
+      const symbolTurnover = Math.abs(position - (previousPosition[symbol] ?? 0));
+      const symbolCost = symbolTurnover * (config.fee + config.slippage / Math.max(symbolCloses[index - 1], 0.01));
+      const symbolGross = position * marketReturn;
+      gross += symbolGross;
+      net += symbolGross - symbolCost;
+      turnover += symbolTurnover;
+      executionCost += symbolCost;
+      activePositions += position;
+      previousPosition[symbol] = position;
+    }
+    if (!complete) continue;
+    const divisor = config.universe.length;
+    const grossReturn = gross / divisor;
+    const netReturn = net / divisor;
+    ledger.push({ date: new Date(timestamp).toISOString().slice(0, 10), grossReturn, netReturn, turnover: turnover / divisor, executionCost: executionCost / divisor, activePositions });
+    path.push(path[path.length - 1] * (1 + netReturn));
+  }
+
+  if (ledger.length < 20) throw new Error("At least 20 aligned market observations are required.");
+  const returns = ledger.map((entry) => entry.netReturn);
+  const totalReturn = path[path.length - 1] / path[0] - 1;
+  const mean = returns.reduce((sum, value) => sum + value, 0) / returns.length;
+  const variance = returns.reduce((sum, value) => sum + (value - mean) ** 2, 0) / Math.max(returns.length - 1, 1);
+  const annualizedVol = Math.sqrt(252 * variance);
+  const sharpe = annualizedVol > 0 ? (Math.sqrt(252) * mean) / Math.sqrt(variance) : 0;
+  let peak = path[0];
+  let drawdown = 0;
+  for (const value of path) { peak = Math.max(peak, value); drawdown = Math.min(drawdown, value / peak - 1); }
+  const sampled = Array.from({ length: 32 }, (_, index) => path[Math.min(path.length - 1, Math.round((index * (path.length - 1)) / 31))]);
+
+  return {
+    id: config.id,
+    label: config.label,
+    changed: config.changed,
+    returnPct: Number((totalReturn * 100).toFixed(2)),
+    sharpe: Number(sharpe.toFixed(3)),
+    drawdown: Number((drawdown * 100).toFixed(2)),
+    annualizedVol: Number((annualizedVol * 100).toFixed(2)),
+    observations: ledger.length,
+    turnover: Number(ledger.reduce((sum, entry) => sum + entry.turnover, 0).toFixed(3)),
+    costPct: Number((ledger.reduce((sum, entry) => sum + entry.executionCost, 0) * 100).toFixed(3)),
+    color: config.color,
+    path: sampled,
+    ledger,
+  };
+}

--- a/instrument/lib/evidence-contract.ts
+++ b/instrument/lib/evidence-contract.ts
@@ -1,0 +1,144 @@
+export type Metric = "net_return" | "max_drawdown" | "sharpe";
+export type Operator = "gt" | "gte" | "lt" | "lte";
+export type PerturbationScope = "any" | "all";
+
+export const EPSILON_SOFTWARE_REVISION = "epsilon-instrument-2026.08.30";
+export const EVIDENCE_LIMITATIONS = [
+  "Adjusted daily close-to-close bars do not model intraday liquidity, market impact, taxes, borrow constraints, or partial fills.",
+  "The artifact checksum detects content changes but is not a digital signature or proof of EPSILON origin.",
+  "Independent reproduction requires equivalent source data and the documented software revision.",
+] as const;
+
+export type FalsificationRule = {
+  metric: Metric;
+  operator: Operator;
+  threshold: number;
+  perturbationScope: PerturbationScope;
+};
+
+export type EvidenceRun = {
+  id: string;
+  label: string;
+  changed: string;
+  returnPct: number;
+  sharpe: number;
+  drawdown: number;
+  annualizedVol: number;
+  observations: number;
+  turnover: number;
+  costPct: number;
+  color: string;
+  path: number[];
+};
+
+export type EvidenceVerdict = {
+  survivalCount: number;
+  testedCount: number;
+  worstCase: number;
+  worstMargin: number;
+  largestSensitivity: { runId: string; label: string; delta: number } | null;
+  nearestFailure: { runId: string; label: string; value: number } | null;
+  verdict: "survives" | "fragile" | "rejected";
+};
+
+export function passesRule(value: number, rule: FalsificationRule) {
+  if (rule.operator === "gt") return value > rule.threshold;
+  if (rule.operator === "gte") return value >= rule.threshold;
+  if (rule.operator === "lt") return value < rule.threshold;
+  return value <= rule.threshold;
+}
+
+export function metricValue(run: Pick<EvidenceRun, "returnPct" | "drawdown" | "sharpe">, metric: Metric) {
+  if (metric === "max_drawdown") return run.drawdown;
+  if (metric === "sharpe") return run.sharpe;
+  return run.returnPct;
+}
+
+function margin(value: number, rule: FalsificationRule) {
+  return rule.operator === "gt" || rule.operator === "gte"
+    ? value - rule.threshold
+    : rule.threshold - value;
+}
+
+export function evaluateEvidence(runs: EvidenceRun[], rule: FalsificationRule): EvidenceVerdict {
+  if (runs.length < 2) throw new Error("Evidence requires one baseline and at least one perturbation.");
+  const baseline = runs[0];
+  const tested = runs.slice(1);
+  const values = runs.map((run) => metricValue(run, rule.metric));
+  const testedValues = tested.map((run) => ({ run, value: metricValue(run, rule.metric) }));
+  const passed = testedValues.filter(({ value }) => passesRule(value, rule));
+  const failures = testedValues
+    .filter(({ value }) => !passesRule(value, rule))
+    .sort((a, b) => Math.abs(margin(a.value, rule)) - Math.abs(margin(b.value, rule)));
+  const sensitivities = tested
+    .map((run) => ({
+      runId: run.id,
+      label: run.label,
+      delta: Number((metricValue(run, rule.metric) - metricValue(baseline, rule.metric)).toFixed(3)),
+    }))
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+  const survivalCount = passed.length;
+  const scopePassed = rule.perturbationScope === "all" ? survivalCount === tested.length : survivalCount > 0;
+
+  return {
+    survivalCount,
+    testedCount: tested.length,
+    worstCase: rule.operator === "gt" || rule.operator === "gte" ? Math.min(...values) : Math.max(...values),
+    worstMargin: Number(Math.min(...testedValues.map(({ value }) => margin(value, rule))).toFixed(3)),
+    largestSensitivity: sensitivities[0] ?? null,
+    nearestFailure: failures[0]
+      ? { runId: failures[0].run.id, label: failures[0].run.label, value: failures[0].value }
+      : null,
+    verdict: scopePassed ? "survives" : survivalCount > 0 ? "fragile" : "rejected",
+  };
+}
+
+export function describeRule(rule: FalsificationRule) {
+  const metric = rule.metric === "net_return" ? "net total return" : rule.metric === "max_drawdown" ? "maximum drawdown" : "annualized Sharpe";
+  const operator = { gt: ">", gte: "≥", lt: "<", lte: "≤" }[rule.operator];
+  const suffix = rule.metric === "sharpe" ? "" : "%";
+  return `Reject the claim unless ${metric} ${operator} ${rule.threshold}${suffix} for ${rule.perturbationScope === "all" ? "every required perturbation" : "at least one perturbation"}.`;
+}
+
+function canonical(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonical);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, entry]) => entry !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonical(entry)]),
+    );
+  }
+  return value;
+}
+
+export function stableStringify(value: unknown) {
+  return JSON.stringify(canonical(value));
+}
+
+export async function evidenceDigest(value: unknown) {
+  const bytes = new TextEncoder().encode(stableStringify(value));
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export async function createEvidenceArtifact<T extends object>(core: T, generatedAt = new Date().toISOString()) {
+  const evidenceId = await evidenceDigest(core);
+  const covered = {
+    ...core,
+    evidenceId,
+    generatedAt,
+    integrity: {
+      algorithm: "SHA-256" as const,
+      scope: "canonical artifact fields excluding artifactHash" as const,
+      authenticity: "checksum only; not a digital signature" as const,
+    },
+  };
+  return { ...covered, artifactHash: await evidenceDigest(covered) };
+}
+
+export async function verifyEvidenceArtifact(artifact: Record<string, unknown>) {
+  const { artifactHash, ...covered } = artifact;
+  return typeof artifactHash === "string" && artifactHash === await evidenceDigest(covered);
+}

--- a/instrument/lib/http.ts
+++ b/instrument/lib/http.ts
@@ -1,0 +1,38 @@
+export class RequestBodyError extends Error {
+  readonly status: 400 | 413;
+
+  constructor(message: string, status: 400 | 413) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export async function readBoundedJson<T>(request: Request, maxBytes: number): Promise<T> {
+  const declaredLength = Number(request.headers.get("content-length") ?? 0);
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    throw new RequestBodyError("Request body is too large.", 413);
+  }
+  if (!request.body) throw new RequestBodyError("Request body must be valid JSON.", 400);
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let text = "";
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        throw new RequestBodyError("Request body is too large.", 413);
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if (error instanceof RequestBodyError) throw error;
+    throw new RequestBodyError("Request body must be valid JSON.", 400);
+  }
+}

--- a/instrument/lib/impact-contract.ts
+++ b/instrument/lib/impact-contract.ts
@@ -1,0 +1,16 @@
+export const clientImpactEvents = ["site_visit", "lab_opened", "challenge_opened", "reproduce_opened"] as const;
+export const verifiedImpactEvents = ["verified_historical_run"] as const;
+export const impactEvents = [...clientImpactEvents, ...verifiedImpactEvents] as const;
+export type ImpactEventName = (typeof impactEvents)[number];
+export type ClientImpactEventName = (typeof clientImpactEvents)[number];
+
+export function isClientImpactEvent(value: unknown): value is ClientImpactEventName {
+  return typeof value === "string" && (clientImpactEvents as readonly string[]).includes(value);
+}
+
+const sourceLabels = ["direct", "internal", "github", "stocktwits", "x", "linkedin", "reddit", "youtube", "producthunt", "substack", "email", "school", "other"] as const;
+
+export function normalizeImpactSource(value: unknown) {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "direct";
+  return (sourceLabels as readonly string[]).includes(normalized) ? normalized : "other";
+}

--- a/instrument/lib/impact.ts
+++ b/instrument/lib/impact.ts
@@ -1,0 +1,71 @@
+import { env } from "cloudflare:workers";
+export { impactEvents, isClientImpactEvent, normalizeImpactSource } from "./impact-contract";
+export type { ClientImpactEventName, ImpactEventName } from "./impact-contract";
+
+export async function ensureImpactSchema() {
+  await env.DB.batch([
+    env.DB.prepare(`CREATE TABLE IF NOT EXISTS impact_events (
+      id TEXT PRIMARY KEY,
+      dedupe_key TEXT NOT NULL UNIQUE,
+      event_name TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      source TEXT NOT NULL,
+      path TEXT NOT NULL,
+      artifact_hash TEXT,
+      mode TEXT,
+      created_at TEXT NOT NULL
+    )`),
+    env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_impact_events_name_created ON impact_events(event_name, created_at)"),
+    env.DB.prepare("CREATE INDEX IF NOT EXISTS idx_impact_events_session ON impact_events(session_id)"),
+    env.DB.prepare(`CREATE TABLE IF NOT EXISTS impact_rate_windows (
+      bucket TEXT PRIMARY KEY,
+      used INTEGER NOT NULL,
+      updated_at TEXT NOT NULL
+    )`),
+  ]);
+}
+
+export function impactDb() {
+  return env.DB;
+}
+
+export async function consumeImpactBudget(units = 1, limit = 120) {
+  if (!Number.isInteger(units) || units < 1 || units > limit) return false;
+  const now = new Date();
+  const bucket = now.toISOString().slice(0, 16);
+  const cutoff = new Date(now.getTime() - 86_400_000).toISOString().slice(0, 16);
+  const retainedAfter = new Date(now.getTime() - 90 * 86_400_000).toISOString();
+  await ensureImpactSchema();
+  const reserved = await env.DB.prepare(`INSERT INTO impact_rate_windows (bucket, used, updated_at)
+    VALUES (?, ?, ?)
+    ON CONFLICT(bucket) DO UPDATE SET
+      used = impact_rate_windows.used + excluded.used,
+      updated_at = excluded.updated_at
+    WHERE impact_rate_windows.used + excluded.used <= ?
+    RETURNING used`)
+    .bind(bucket, units, now.toISOString(), limit)
+    .first<{ used: number }>();
+  if (!reserved) return false;
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM impact_rate_windows WHERE bucket < ?").bind(cutoff),
+    env.DB.prepare("DELETE FROM impact_events WHERE created_at < ?").bind(retainedAfter),
+  ]);
+  return true;
+}
+
+export async function pruneImpactEvents(now = new Date()) {
+  const retainedAfter = new Date(now.getTime() - 90 * 86_400_000).toISOString();
+  await ensureImpactSchema();
+  await env.DB.prepare("DELETE FROM impact_events WHERE created_at < ?").bind(retainedAfter).run();
+  return retainedAfter;
+}
+
+export async function recordVerifiedHistoricalRun(evidenceId: string, artifactHash: string, createdAt: string) {
+  await ensureImpactSchema();
+  const id = `verified:${evidenceId}`;
+  await env.DB.prepare(`INSERT OR IGNORE INTO impact_events
+    (id, dedupe_key, event_name, session_id, source, path, artifact_hash, mode, created_at)
+    VALUES (?, ?, 'verified_historical_run', ?, 'server', '/api/evidence/run', ?, 'historical-market-data', ?)`)
+    .bind(crypto.randomUUID(), id, id, artifactHash, createdAt)
+    .run();
+}

--- a/instrument/lib/provider-cache.ts
+++ b/instrument/lib/provider-cache.ts
@@ -1,0 +1,3 @@
+export function missingProviderSymbols(symbols: string[], lookup: (symbol: string) => unknown) {
+  return symbols.filter((symbol) => !lookup(symbol));
+}

--- a/instrument/lib/rate-limit.ts
+++ b/instrument/lib/rate-limit.ts
@@ -1,0 +1,28 @@
+type RateEntry = { count: number; resetAt: number };
+type RateStore = Map<string, RateEntry>;
+
+const runtimeState = globalThis as typeof globalThis & { epsilonRateStores?: Map<string, RateStore> };
+const stores = runtimeState.epsilonRateStores ?? new Map<string, RateStore>();
+runtimeState.epsilonRateStores = stores;
+
+export function clientKey(request: Request) {
+  return (request.headers.get("cf-connecting-ip") ?? "anonymous").slice(0, 64);
+}
+
+export function checkRateLimit(request: Request, bucket: string, limit: number, windowMs = 60_000) {
+  const now = Date.now();
+  const store = stores.get(bucket) ?? new Map<string, RateEntry>();
+  stores.set(bucket, store);
+  if (store.size > 1_000) {
+    for (const [key, entry] of store) if (entry.resetAt <= now) store.delete(key);
+    while (store.size > 1_000) store.delete(store.keys().next().value as string);
+  }
+  const key = clientKey(request);
+  const entry = store.get(key);
+  if (!entry || entry.resetAt <= now) {
+    store.set(key, { count: 1, resetAt: now + windowMs });
+    return { limited: false, retryAfter: 0 };
+  }
+  entry.count += 1;
+  return { limited: entry.count > limit, retryAfter: Math.max(1, Math.ceil((entry.resetAt - now) / 1_000)) };
+}

--- a/instrument/lib/synthetic.ts
+++ b/instrument/lib/synthetic.ts
@@ -1,0 +1,49 @@
+import type { EvidenceRun } from "./evidence-contract";
+import type { LedgerEntry, Strategy } from "./backtest";
+
+const COLORS = ["#f5f5f0", "#a88cff", "#ff8b5d", "#4dd9c0", "#ffc857", "#ef5da8"];
+
+function hash(value: string) {
+  let result = 2166136261;
+  for (let index = 0; index < value.length; index += 1) result = Math.imul(result ^ value.charCodeAt(index), 16777619);
+  return Math.abs(result >>> 0);
+}
+
+function pathFor(seed: number, terminal: number) {
+  const points = [100];
+  for (let index = 1; index < 32; index += 1) {
+    const wave = Math.sin((seed % 19 + index) * 0.71) * 0.52 + Math.cos((seed % 11 + index) * 0.37) * 0.32;
+    points.push(Math.max(88, points[index - 1] + terminal / 31 + wave));
+  }
+  const adjustment = 100 + terminal - points[points.length - 1];
+  return points.map((point, index) => Number((point + adjustment * (index / (points.length - 1))).toFixed(4)));
+}
+
+function ledgerFor(path: number[], start: string): LedgerEntry[] {
+  const origin = Date.parse(`${start}T00:00:00Z`);
+  return path.slice(1).map((value, index) => ({ date: new Date(origin + (index + 1) * 86_400_000).toISOString().slice(0, 10), grossReturn: value / path[index] - 1, netReturn: value / path[index] - 1, turnover: 0, executionCost: 0, activePositions: 1 }));
+}
+
+export function makeSyntheticRuns(config: { strategy: Strategy; start: string; end: string; universe: string; fee: number; slippage: number }) {
+  const seed = hash(`${config.strategy}|${config.start}|${config.end}|${config.universe}`);
+  const baseline = 1.8 + (seed % 470) / 100;
+  const feeImpact = config.fee * 4 * 760;
+  const slipImpact = config.slippage * 4 * 18;
+  const windowImpact = 0.45 + ((seed >> 3) % 155) / 100;
+  const universeImpact = 0.3 + ((seed >> 6) % 105) / 100;
+  const symbols = config.universe.split(",").map((symbol) => symbol.trim()).filter(Boolean);
+  const narrow = symbols.slice(0, Math.max(1, Math.ceil(symbols.length / 2))).join(",");
+  const outcomes = [
+    { id: "baseline", label: "Baseline", changed: "None", result: baseline, costPct: (config.fee + config.slippage / 100) * 100 },
+    { id: "epsilon-1", label: "Fee ×5", changed: `${config.fee} → ${Number((config.fee * 5).toFixed(5))}`, result: baseline - feeImpact, costPct: (config.fee * 5 + config.slippage / 100) * 100 },
+    { id: "epsilon-2", label: "Slippage ×5", changed: `$${config.slippage} → $${Number((config.slippage * 5).toFixed(3))}`, result: baseline - slipImpact, costPct: (config.fee + (config.slippage * 5) / 100) * 100 },
+    { id: "epsilon-3", label: "Window +30d", changed: `${config.start} → shifted +30 days`, result: baseline - windowImpact, costPct: (config.fee + config.slippage / 100) * 100 },
+    { id: "epsilon-4", label: "Narrow universe", changed: `${config.universe} → ${narrow}`, result: baseline - universeImpact, costPct: (config.fee + config.slippage / 100) * 100 },
+    { id: "epsilon-5", label: "Joint execution stress", changed: "Fee ×5 + slippage ×5 + window +30d", result: baseline - feeImpact - slipImpact - windowImpact, costPct: (config.fee * 5 + (config.slippage * 5) / 100) * 100 },
+  ];
+  const runs: Array<EvidenceRun & { ledger: LedgerEntry[] }> = outcomes.map((outcome, index) => {
+    const path = pathFor(seed + index * 97, outcome.result);
+    return { id: outcome.id, label: outcome.label, changed: outcome.changed, returnPct: Number(outcome.result.toFixed(2)), sharpe: Number((0.58 + outcome.result / 4.2).toFixed(3)), drawdown: Number((-0.65 - Math.abs(baseline - outcome.result) * 0.48).toFixed(2)), annualizedVol: Number((8.4 + Math.abs(baseline - outcome.result) * 0.7).toFixed(2)), observations: 31, turnover: Number((0.9 + index * 0.18).toFixed(3)), costPct: Number(outcome.costPct.toFixed(3)), color: COLORS[index], path, ledger: ledgerFor(path, config.start) };
+  });
+  return runs;
+}

--- a/instrument/lib/utils.ts
+++ b/instrument/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/instrument/tests/evidence-contract.test.ts
+++ b/instrument/tests/evidence-contract.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { evidenceDigest, evaluateEvidence, type EvidenceRun, type FalsificationRule } from "../lib/evidence-contract.ts";
+import { createEvidenceArtifact, evidenceDigest, evaluateEvidence, verifyEvidenceArtifact, type EvidenceRun, type FalsificationRule } from "../lib/evidence-contract.ts";
 
 function run(id: string, value: number): EvidenceRun {
   return { id, label: id, changed: "test", returnPct: value, sharpe: value, drawdown: -value, annualizedVol: 1, observations: 30, turnover: 1, costPct: 0, color: "#fff", path: [100, 100 + value] };
@@ -15,4 +15,14 @@ void test("verdict distinguishes survival, fragility, and rejection", () => {
 
 void test("canonical evidence digest is independent of object key order", async () => {
   assert.equal(await evidenceDigest({ b: 2, a: { y: 2, x: 1 } }), await evidenceDigest({ a: { x: 1, y: 2 }, b: 2 }));
+});
+
+void test("artifact checksum covers generation time and all exported fields except itself", async () => {
+  const first = await createEvidenceArtifact({ claim: "test" }, "2026-01-01T00:00:00.000Z");
+  const second = await createEvidenceArtifact({ claim: "test" }, "2026-01-02T00:00:00.000Z");
+  assert.notEqual(first.artifactHash, second.artifactHash);
+  assert.equal(first.evidenceId, second.evidenceId);
+  assert.equal(await verifyEvidenceArtifact(first), true);
+  assert.equal(await verifyEvidenceArtifact({ ...first, generatedAt: second.generatedAt }), false);
+  assert.equal(await verifyEvidenceArtifact({ ...first, artifactHash: "0".repeat(64) }), false);
 });

--- a/instrument/tests/security-boundaries.test.ts
+++ b/instrument/tests/security-boundaries.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readBoundedJson, RequestBodyError } from "../lib/http.ts";
+import { isClientImpactEvent, normalizeImpactSource } from "../lib/impact-contract.ts";
+import { missingProviderSymbols } from "../lib/provider-cache.ts";
+
+void test("bounded JSON reader accepts a legitimate request", async () => {
+  const request = new Request("https://epsilon.test/api", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ claim: "test" }),
+  });
+  assert.deepEqual(await readBoundedJson(request, 128), { claim: "test" });
+});
+
+void test("bounded JSON reader rejects streamed bodies without relying on Content-Length", async () => {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(`{"value":"${"x".repeat(256)}"}`));
+      controller.close();
+    },
+  });
+  const request = new Request("https://epsilon.test/api", { method: "POST", body, duplex: "half" } as RequestInit & { duplex: "half" });
+  await assert.rejects(() => readBoundedJson(request, 64), (error: unknown) => error instanceof RequestBodyError && error.status === 413);
+});
+
+void test("client telemetry cannot assert verified research use", () => {
+  assert.equal(isClientImpactEvent("lab_opened"), true);
+  assert.equal(isClientImpactEvent("verified_historical_run"), false);
+  assert.equal(isClientImpactEvent("evidence_completed"), false);
+});
+
+void test("campaign sources collapse to coarse non-identifying categories", () => {
+  assert.equal(normalizeImpactSource("github"), "github");
+  assert.equal(normalizeImpactSource("student@example.com"), "other");
+  assert.equal(normalizeImpactSource("recipient-12345"), "other");
+});
+
+void test("provider budget is calculated only from cache misses", () => {
+  const cached = new Set(["SPY", "QQQ"]);
+  assert.deepEqual(missingProviderSymbols(["SPY", "QQQ"], (symbol) => cached.has(symbol)), []);
+  assert.deepEqual(missingProviderSymbols(["SPY", "IWM"], (symbol) => cached.has(symbol)), ["IWM"]);
+});


### PR DESCRIPTION
## Summary

- record historical experiments only after the server completes a real-data run
- reject client-forged research events and bound telemetry/evidence request bodies
- separate verified experiments from unverified browser signals on the public impact record
- make evidence IDs stable while checksums cover the complete exported artifact
- add D1 write budgets, retention cleanup, and migration coverage

## Verification

- `npm ci` — 0 vulnerabilities
- `npm run check` — 11/11 tests, TypeScript, and oxlint passed
- `npm run build` — production build passed
- production smoke test — Massive SPY historical run returned `epsilon.evidence.v2`
- forged `verified_historical_run` telemetry returned HTTP 400

## Public product

The corresponding Sites version is already live at https://epsilonfield.space. This PR aligns the public GitHub source with that deployed version.